### PR TITLE
feat: add --cpu host to mte vms' xml to allow using of nested virt

### DIFF
--- a/maintenance/fuel-pm.sh
+++ b/maintenance/fuel-pm.sh
@@ -45,6 +45,7 @@ fi
 sudo virt-install -n $VM_NAME \
  -r $master_ram \
  --vcpus=$master_vcpus \
+ --cpu host \
  --arch=x86_64 \
  --disk path=$PATH_TO_ENV/fuel-pm.qcow2,bus=virtio,device=disk,format=qcow2 \
  --cdrom $iso_path \

--- a/maintenance/fuel-slaves.sh
+++ b/maintenance/fuel-slaves.sh
@@ -70,6 +70,7 @@ do
 	sudo virt-install -n $VM_NAME \
 	 -r ${slave_ram[$i]} \
 	 --vcpus=${slave_vcpus[$i]} \
+         --cpu host \
 	 --arch=x86_64 \
 	 $virt_disks_params \
 	 $virt_net_params \

--- a/scripts/3-launch-vms.sh
+++ b/scripts/3-launch-vms.sh
@@ -47,6 +47,7 @@ if [ $? -eq 0 ] ; then sudo virsh destroy $VM_NAME ; sudo virsh undefine $VM_NAM
 sudo virt-install -n $VM_NAME \
  -r $master_ram \
  --vcpus=$master_vcpus \
+ --cpu host \
  --arch=x86_64 \
  --disk path=$PATH_TO_ENV/statedir/diff.fuel-pm.qcow2,bus=virtio,device=disk,format=qcow2 \
  $virt_net_params \
@@ -138,6 +139,7 @@ do
 	sudo virt-install -n $VM_NAME \
 	 -r ${slave_ram[$i]} \
 	 --vcpus=${slave_vcpus[$i]} \
+         --cpu host \
 	 --arch=x86_64 \
 	 $virt_disks_params \
 	 $virt_net_params \


### PR DESCRIPTION
So all cpu features avaiable on host machine will be exposed to your mte,
and you will be able to use kvm instead of qemu inside your openstack
See more details at
http://kashyapc.com/2012/01/14/nested-virtualization-with-kvm-intel/
