### PR TITLE
feat: make vms use virtio driver for net interfaces.

### DIFF
--- a/maintenance/fuel-pm.sh
+++ b/maintenance/fuel-pm.sh
@@ -19,7 +19,7 @@ do
 		net_name=$net_prefix-${subnet_name[$i]}
 	fi
 
-	virt_net_params="$virt_net_params --bridge=$net_name,mac=${subnet_mac_prefix[$i]}:00"
+	virt_net_params="$virt_net_params --bridge=$net_name,mac=${subnet_mac_prefix[$i]}:00,model=virtio"
 done
 
 if [ -z $master_ram ]

--- a/maintenance/fuel-slaves.sh
+++ b/maintenance/fuel-slaves.sh
@@ -28,7 +28,7 @@ do
 			net_name=$net_prefix-${subnet_name[$j]}
 		fi
 
-		virt_net_params="$virt_net_params --bridge=$net_name,mac=${subnet_mac_prefix[$j]}:$MACNUM"
+		virt_net_params="$virt_net_params --bridge=$net_name,mac=${subnet_mac_prefix[$j]}:$MACNUM,model=virtio"
 	done
 
 	if [ -z ${node_disks[$i]} ]

--- a/scripts/3-launch-vms.sh
+++ b/scripts/3-launch-vms.sh
@@ -19,7 +19,7 @@ do
 		net_name=$net_prefix-${subnet_name[$i]}
 	fi
 
-	virt_net_params="$virt_net_params --bridge=$net_name,mac=${subnet_mac_prefix[$i]}:00"
+	virt_net_params="$virt_net_params --bridge=$net_name,mac=${subnet_mac_prefix[$i]}:00,model=virtio"
 done
 
 if [ -z $master_ram ]
@@ -95,7 +95,7 @@ do
 			net_name=$net_prefix-${subnet_name[$j]}
 		fi
 
-		virt_net_params="$virt_net_params --bridge=$net_name,mac=${subnet_mac_prefix[$j]}:$MACNUM"
+		virt_net_params="$virt_net_params --bridge=$net_name,mac=${subnet_mac_prefix[$j]}:$MACNUM,model=virtio"
 	done
 
 	if [ -z ${node_disks[$i]} ]


### PR DESCRIPTION
see also:
https://www.sebastien-han.fr/blog/2012/07/19/make-the-network-of-your-vms-fly-with-virtio-driver/

Note that we can achieve the same by specifing os-variant in virt-install command,
but possible values for this parameter depends on virt-install version that you use.
E.g see the output of 'osinfo-query os'. OSes have different names on ubuntu and cenots.
So just directly passing virtio as driver name is more universal
