### PR TITLE
feat: make pause_before_slaves configurable parameter in env.cfg

### DIFF
--- a/env-template/env.cfg
+++ b/env-template/env.cfg
@@ -124,6 +124,11 @@ node_3_disk_1_size=100G
 node_4_disk_1_size=100G
 node_5_disk_1_size=100G
 
+# You can set a delay between deployment of fuel master and start deployment of slaves.
+# Note that there is preparation/wait-for-master.sh, which is used to detect when master node is ready.
+# Uncomment this so the scripts react to this variable; this will be passed as a parameter to 'sleep'.
+pause_before_slaves=0
+
 # You can set a delay between each slave node starting.
 # Uncomment this so the scripts react to this variable; this will be passed as a parameter to 'sleep'.
 #pause_between_slaves=2m

--- a/scripts/3-launch-vms.sh
+++ b/scripts/3-launch-vms.sh
@@ -66,8 +66,13 @@ sudo virsh vncdisplay $VM_NAME
 
 echo "Waiting for fuel master to become ready..."
 $PATH_TO_ENV/preparation/wait-for-master.sh
-echo "Master node is ready! Waiting 30 seconds before proceeding..."
-sleep 30
+
+if [ -z $pause_before_slaves ] 
+then
+	pause_before_slaves=30
+fi
+echo "Master node is ready! Waiting ${pause_before_slaves} seconds before proceeding..."
+sleep pause_before_slaves
 
 for i in $(seq 1 $slaves_count)
 do


### PR DESCRIPTION
pause_before_slaves used to be needed when boot order of slaves was
pxe. Now but order is pxe,hd(commit 5debf418).
So even if master is not ready it is not necessary to wait for it.
That's why in env.cfg template it is set to 0.
