### PR TITLE
Feat: add console output file for vms.

### DIFF
--- a/destroy-env.sh
+++ b/destroy-env.sh
@@ -39,6 +39,7 @@ echo "Destroying remaining networks..."
 
 echo "Removing diff qcow2's..."
 sudo rm $PATH_TO_ENV/statedir/diff*
+sudo rm $PATH_TO_ENV/statedir/*.log
 
 rm -f $PATH_TO_ENV/statedir/inet_if
 

--- a/scripts/3-launch-vms.sh
+++ b/scripts/3-launch-vms.sh
@@ -59,6 +59,7 @@ sudo virt-install -n $VM_NAME \
  $virt_net_params \
  --boot hd \
  --noautoconsole \
+ --serial file,path=$PATH_TO_ENV/statedir/${VM_NAME}.log \
  --graphics vnc,listen=0.0.0.0 
 if [ $? -ne 0 ]
 then
@@ -166,6 +167,7 @@ do
 	 $virt_net_params \
 	 --boot network,hd \
 	 --noautoconsole \
+         --serial file,path=$PATH_TO_ENV/statedir/${VM_NAME}.log \
 	 --graphics vnc,listen=0.0.0.0
 	if [ $? -ne 0 ]
 	then


### PR DESCRIPTION
If you add the following line to your vms' kernel options:
console=tty0 console=ttyS0,115200n8
you will see console logs in the file, just like openstack.

Surprisingly, in 6.1 console enabled by default for vms(not for fuel master). May be because of cloud-init, that is mistakenly installed?